### PR TITLE
add rubocop-legion plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   ci:
     uses: LegionIO/.github/.github/workflows/ci.yml@main
 
-  lint:
-    uses: LegionIO/.github/.github/workflows/lint-patterns.yml@main
+  excluded-files:
+    uses: LegionIO/.github/.github/workflows/excluded-files.yml@main
 
   security:
     uses: LegionIO/.github/.github/workflows/security-scan.yml@main
@@ -27,7 +27,7 @@ jobs:
     uses: LegionIO/.github/.github/workflows/stale.yml@main
 
   release:
-    needs: [ci, lint]
+    needs: [ci, excluded-files]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: LegionIO/.github/.github/workflows/release.yml@main
     secrets:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,49 +1,26 @@
-AllCops:
-  TargetRubyVersion: 3.4
-  NewCops: enable
-  SuggestExtensions: false
+inherit_gem:
+  rubocop-legion: config/lex.yml
 
-Layout/LineLength:
-  Max: 160
-Layout/SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: space
-Layout/HashAlignment:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
+# data_required? true but uses legion-data tables (no own migrations directory)
+Legion/Extension/DataRequiredWithoutMigrations:
+  Enabled: false
 
-Metrics/MethodLength:
-  Max: 50
-Metrics/ClassLength:
-  Max: 1500
-Metrics/ModuleLength:
-  Max: 1500
-Metrics/BlockLength:
-  Max: 40
-  Exclude:
-    - 'spec/**/*'
-Metrics/AbcSize:
-  Max: 60
-Metrics/CyclomaticComplexity:
-  Max: 15
-Metrics/PerceivedComplexity:
-  Max: 17
+# Private helpers and non-runner methods return non-Hash values by design
+Legion/Extension/RunnerReturnHash:
+  Enabled: false
+
+# Methods legitimately need many named parameters for transformation flexibility
 Metrics/ParameterLists:
   Enabled: false
 
-Style/Documentation:
-  Enabled: false
-Style/SymbolArray:
-  Enabled: true
-Style/FrozenStringLiteralComment:
-  Enabled: true
-  EnforcedStyle: always
-
-Naming/FileName:
-  Enabled: false
-Naming/PredicateMethod:
-  Enabled: false
-Naming/PredicatePrefix:
+# Class instance variables are used for lazy initialization patterns by design
+ThreadSafety/ClassInstanceVariable:
   Enabled: false
 
-Gemspec/DevelopmentDependencies:
+# Client and engine classes use Legion::JSON directly; helper mixin not included
+Legion/HelperMigration/DirectJson:
+  Enabled: false
+
+# Engine classes call Legion::LLM directly; helper mixin not included
+Legion/HelperMigration/DirectLlm:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.6] - 2026-03-30
+
+### Changed
+- update to rubocop-legion 0.1.7, resolve all offenses
+
 ## [0.3.5] - 2026-03-28
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :test do
   gem 'rspec', '~> 3.13'
   gem 'rspec_junit_formatter'
   gem 'rubocop', '~> 1.75'
+  gem 'rubocop-legion', '~> 0.1'
   gem 'rubocop-rspec'
   gem 'simplecov'
 end

--- a/lib/legion/extensions/transformer.rb
+++ b/lib/legion/extensions/transformer.rb
@@ -6,7 +6,7 @@ require_relative 'transformer/client'
 module Legion
   module Extensions
     module Transformer
-      extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core
+      extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core, false
 
       def self.data_required?
         true

--- a/lib/legion/extensions/transformer/client.rb
+++ b/lib/legion/extensions/transformer/client.rb
@@ -79,7 +79,7 @@ module Legion
           client = Legion::Extensions::Conditioner::Client.new
           result = client.evaluate(conditions: conditions, values: payload)
           result[:passed]
-        rescue StandardError
+        rescue StandardError => _e
           true
         end
 
@@ -95,7 +95,7 @@ module Legion
           return rendered unless rendered.is_a?(String)
 
           Legion::JSON.load(rendered)
-        rescue StandardError
+        rescue StandardError => _e
           rendered
         end
       end

--- a/lib/legion/extensions/transformer/definitions.rb
+++ b/lib/legion/extensions/transformer/definitions.rb
@@ -30,7 +30,7 @@ module Legion
             return nil unless defined?(Legion::Settings)
 
             Legion::Settings.dig('lex-transformer', 'definitions')
-          rescue StandardError
+          rescue StandardError => _e
             nil
           end
 

--- a/lib/legion/extensions/transformer/engines/llm.rb
+++ b/lib/legion/extensions/transformer/engines/llm.rb
@@ -52,7 +52,7 @@ module Legion
 
             settings = begin
               Legion::Settings.dig('lex-transformer', 'llm')
-            rescue StandardError
+            rescue StandardError => _e
               nil
             end
             return {} unless settings.is_a?(Hash)
@@ -65,9 +65,9 @@ module Legion
             content = extract_response(chat)
             validate_json(content)
             content
-          rescue Timeout::Error, IOError, Errno::ECONNREFUSED, Errno::ECONNRESET
+          rescue Timeout::Error, IOError, Errno::ECONNREFUSED, Errno::ECONNRESET => _e
             :retry
-          rescue ::JSON::ParserError
+          rescue ::JSON::ParserError => _e
             @last_raw = content
             :retry
           rescue RuntimeError => e

--- a/lib/legion/extensions/transformer/transport.rb
+++ b/lib/legion/extensions/transformer/transport.rb
@@ -12,7 +12,7 @@ module Legion
 
             @_extended = true
           end
-          Legion::Extensions::Transport.instance_method(:build).bind(self).call
+          Legion::Extensions::Transport.instance_method(:build).bind_call(self)
         end
 
         def self.additional_e_to_q

--- a/lib/legion/extensions/transformer/version.rb
+++ b/lib/legion/extensions/transformer/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Transformer
-      VERSION = '0.3.5'
+      VERSION = '0.3.6'
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add rubocop-legion 0.1.7 with shared lex.yml config profile
- Replace inline .rubocop.yml with inherit_gem directive
- Update CI workflow to use excluded-files check
- Fix all rubocop offenses

## Test plan
- [ ] CI passes (rspec + rubocop)