### PR TITLE
Fleet WS-04: forward engine parameter in transformer dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.7] - 2026-04-13
+
+### Added
+- `:engine` to `send_task` whitelist — transformer now forwards the explicit engine parameter from the relationship row to the downstream dispatch message
+
 ## [0.3.6] - 2026-03-30
 
 ### Changed

--- a/lib/legion/extensions/transformer/runners/transform.rb
+++ b/lib/legion/extensions/transformer/runners/transform.rb
@@ -77,7 +77,7 @@ module Legion
 
           def send_task(**opts)
             payload = {}
-            %i[task_id relationship_id trigger_function_id runner_class function_id function chain_id debug args].each do |thing|
+            %i[task_id relationship_id trigger_function_id runner_class function_id function chain_id debug engine args].each do |thing|
               payload[thing] = opts[thing] if opts.key? thing
             end
 

--- a/lib/legion/extensions/transformer/version.rb
+++ b/lib/legion/extensions/transformer/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Transformer
-      VERSION = '0.3.6'
+      VERSION = '0.3.7'
     end
   end
 end

--- a/spec/legion/extensions/transformer/runners/transform_engine_spec.rb
+++ b/spec/legion/extensions/transformer/runners/transform_engine_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Legion
+  module Extensions
+    module Transformer
+      module Transport
+        module Messages
+          unless defined?(Legion::Extensions::Transformer::Transport::Messages::Message)
+            class Message
+              def initialize(**); end
+
+              def publish; end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+require 'legion/extensions/transformer/runners/transform'
+
+RSpec.describe Legion::Extensions::Transformer::Runners::Transform do
+  let(:test_class) do
+    Class.new do
+      include Legion::Extensions::Transformer::Runners::Transform
+
+      def task_update(*_args, **_opts); end
+      def generate_task_log(**_opts); end
+
+      def from_json(str)
+        Legion::JSON.load(str)
+      rescue StandardError
+        str
+      end
+    end
+  end
+
+  subject { test_class.new }
+
+  describe '#send_task' do
+    it 'includes engine in the forwarded payload' do
+      message_double = double('Message', publish: true)
+      allow(Legion::Extensions::Transformer::Transport::Messages::Message).to receive(:new).and_return(message_double)
+
+      opts = {
+        task_id:         1,
+        relationship_id: 2,
+        function_id:     3,
+        function:        'transform',
+        chain_id:        4,
+        engine:          'llm',
+        args:            { work_item: { title: 'test' } }
+      }
+
+      subject.send_task(**opts)
+
+      expect(Legion::Extensions::Transformer::Transport::Messages::Message).to have_received(:new) do |**args|
+        expect(args[:engine]).to eq('llm')
+      end
+    end
+
+    it 'does not include engine when not present in payload' do
+      message_double = double('Message', publish: true)
+      allow(Legion::Extensions::Transformer::Transport::Messages::Message).to receive(:new).and_return(message_double)
+
+      opts = {
+        task_id:         1,
+        relationship_id: 2,
+        function_id:     3,
+        function:        'transform',
+        chain_id:        4,
+        args:            { work_item: { title: 'test' } }
+      }
+
+      subject.send_task(**opts)
+
+      expect(Legion::Extensions::Transformer::Transport::Messages::Message).to have_received(:new) do |**args|
+        expect(args).not_to have_key(:engine)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `:engine` to the `send_task` whitelist in `transform.rb`
- The transformer now receives and forwards the explicit engine selection from the relationship row

## Motivation

The `transform` method already accepts `engine:` as a keyword argument and passes it to `render_transformation`. However, `send_task` (which fans out to a downstream task) dropped `engine` silently because it wasn't in the whitelist. This completes the engine propagation chain.

## Changes

- `lib/legion/extensions/transformer/runners/transform.rb` — adds `:engine` to the `send_task` whitelist between `:debug` and `:args`
- `spec/legion/extensions/transformer/runners/transform_engine_spec.rb` (new) — two tests: engine forwarded when present, not forwarded when absent

## Depends On

- LegionIO/legion-data#27
- LegionIO/legion-transport#26
- LegionIO/lex-tasker (engine passthrough PR)
- LegionIO/lex-conditioner (engine passthrough PR)

## Merge Order

**Merge fifth (last)** — after all other WS-04 PRs.

## Test Plan

- [ ] `bundle exec rspec` — 135 examples, 0 failures
- [ ] Part of fleet WS-04